### PR TITLE
Remove useless env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dynwalls/__pycache__

--- a/dynwalls/__init__.py
+++ b/dynwalls/__init__.py
@@ -9,9 +9,9 @@ dynwalls - Use Mac OS dynamic wallpapers on linux
 
 
 if "XDG_DATA_HOME" in os.environ:
-    DATA_DIR = os.environ.get("XDG_DATA_HOME") + "/dynwalls/"
+    DATA_DIR = os.environ.get("XDG_DATA_HOME") + "/dynwalls"
 else:
-    DATA_DIR = os.environ.get("HOME")+"/.local/share/dynwalls/"
+    DATA_DIR = os.environ.get("HOME")+"/.local/share/dynwalls"
 
 if not os.path.isdir(DATA_DIR):
     try:

--- a/dynwalls/__init__.py
+++ b/dynwalls/__init__.py
@@ -9,9 +9,9 @@ dynwalls - Use Mac OS dynamic wallpapers on linux
 
 
 if "XDG_DATA_HOME" in os.environ:
-    DATA_DIR = os.environ.get("XDG_DATA_HOME") + "/dynwalls"
+    DATA_DIR = os.environ.get("XDG_DATA_HOME") + "/systemd/user"
 else:
-    DATA_DIR = os.environ.get("HOME")+"/.local/share/dynwalls"
+    DATA_DIR = os.environ.get("HOME")+"/.local/share/systemd/user"
 
 if not os.path.isdir(DATA_DIR):
     try:

--- a/dynwalls/__init__.py
+++ b/dynwalls/__init__.py
@@ -9,16 +9,20 @@ dynwalls - Use Mac OS dynamic wallpapers on linux
 
 
 if "XDG_DATA_HOME" in os.environ:
-    DATA_DIR = os.environ.get("XDG_DATA_HOME") + "/systemd/user"
+    DATA_DIR = os.environ.get("XDG_DATA_HOME") + "/dynwalls"
+    SYSTEMD_DIR = os.environ.get("XDG_DATA_HOME") + "/systemd/user"
 else:
-    DATA_DIR = os.environ.get("HOME")+"/.local/share/systemd/user"
+    DATA_DIR = os.environ.get("HOME") + "/.local/share/dynwalls"
+    SYSTEMD_DIR = os.environ.get("HOME") + "/.local/share/systemd/user"
 
-if not os.path.isdir(DATA_DIR):
-    try:
-        os.makedirs(DATA_DIR)
-    except sys.OSError:
-        print(f"Couldn't create data directory in {DATA_DIR}", file=sys.stderr)
-        sys.exit(1)
+try:
+	if not os.path.isdir(DATA_DIR) and not os.path.islink(DATA_DIR):
+		os.makedirs(DATA_DIR)
+	if not os.path.isdir(SYSTEMD_DIR) and not os.path.islink(SYSTEMD_DIR):
+		os.makedirs(SYSTEMD_DIR)
+except sys.OSError:
+	print(f"Couldn't create data directory in {DATA_DIR}", file=sys.stderr)
+	sys.exit(1)
 
 config = Config(DATA_DIR)
 

--- a/dynwalls/__main__.py
+++ b/dynwalls/__main__.py
@@ -12,7 +12,6 @@ import heic
 
 from pprint import pprint
 
-from __init__ import DATA_DIR
 from __init__ import WP_DIR
 from __init__ import PREFIX
 from __init__ import EXTENSION

--- a/dynwalls/config.py
+++ b/dynwalls/config.py
@@ -36,4 +36,4 @@ class Config:
         except json.JSONDecodeError:
             print("Invalid config")
         except FileNotFoundError:
-            print("No COnfig specified so far")
+            print("No Config specified so far")

--- a/dynwalls/systemd.py
+++ b/dynwalls/systemd.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 
-from __init__ import DATA_DIR
+from __init__ import SYSTEMD_DIR
 
 
 timerskeleton = \
@@ -33,9 +33,8 @@ ExecStart={} {} update
 
 DEFAULT_TIMERNAME = "dynwalls.timer"
 
-DEFAULT_TIMERFILE = DATA_DIR + "/" + DEFAULT_TIMERNAME
-DEFAULT_SERVICEFILE = DATA_DIR + "/dynwalls.service"
-DEFAULT_UNITDIR = os.environ.get("HOME") + "/.local/share/systemd/user/"
+DEFAULT_TIMERFILE = SYSTEMD_DIR + "/" + DEFAULT_TIMERNAME
+DEFAULT_SERVICEFILE = SYSTEMD_DIR + "/dynwalls.service"
 
 
 
@@ -72,7 +71,7 @@ def reload():
 def setup_units(timelist
                 ,timerfile=DEFAULT_TIMERFILE
                 ,servicefile=DEFAULT_SERVICEFILE
-                ,unitdir=DEFAULT_UNITDIR):
+                ,unitdir=SYSTEMD_DIR):
 
     _create_timer(timelist, filename=timerfile)
     _create_service(filename=servicefile)

--- a/dynwalls/systemd.py
+++ b/dynwalls/systemd.py
@@ -35,8 +35,8 @@ ExecStart={} {} update
 
 DEFAULT_TIMERNAME = "dynwalls.timer"
 
-DEFAULT_TIMERFILE = DATA_DIR + DEFAULT_TIMERNAME
-DEFAULT_SERVICEFILE = DATA_DIR + "dynwalls.service"
+DEFAULT_TIMERFILE = DATA_DIR + "/" + DEFAULT_TIMERNAME
+DEFAULT_SERVICEFILE = DATA_DIR + "/dynwalls.service"
 DEFAULT_UNITDIR = os.environ.get("HOME") + "/.local/share/systemd/user/"
 
 

--- a/dynwalls/systemd.py
+++ b/dynwalls/systemd.py
@@ -70,8 +70,7 @@ def reload():
 
 def setup_units(timelist
                 ,timerfile=DEFAULT_TIMERFILE
-                ,servicefile=DEFAULT_SERVICEFILE
-                ,unitdir=SYSTEMD_DIR):
+                ,servicefile=DEFAULT_SERVICEFILE):
 
     _create_timer(timelist, filename=timerfile)
     _create_service(filename=servicefile)

--- a/dynwalls/systemd.py
+++ b/dynwalls/systemd.py
@@ -55,28 +55,6 @@ def _create_service(filename=DEFAULT_SERVICEFILE):
         f.write(servicetext)
 
 
-def _install_files(timerfile=DEFAULT_TIMERFILE
-                  ,servicefile=DEFAULT_SERVICEFILE
-                  ,unitdir=DEFAULT_UNITDIR):
-    def lnabs(src,dst):
-        if not src.startswith("/"):
-            src = os.getcwd() + f"/{src}"
-        if not dst.startswith("/"):
-            dst = os.getcwd() + f"/{dst}"
-        if os.path.isdir(dst):
-            dst = dst + "/" + src.split("/")[-1]
-        if os.path.islink(dst):
-            os.remove(dst)
-        os.symlink(src,dst)
-
-    if not os.path.isdir(unitdir):
-        os.makedirs(unitdir)
-    lnabs(timerfile,unitdir)
-    lnabs(servicefile,unitdir)
-    reload()
-
-
-
 def enable_timer(timername=DEFAULT_TIMERNAME):
     reload()
     args = ["systemctl", "--user", "enable", "--now", timername]
@@ -98,6 +76,4 @@ def setup_units(timelist
 
     _create_timer(timelist, filename=timerfile)
     _create_service(filename=servicefile)
-    _install_files(timerfile=timerfile
-                   ,servicefile=servicefile
-                   ,unitdir=unitdir)
+    reload()

--- a/dynwalls/systemd.py
+++ b/dynwalls/systemd.py
@@ -28,10 +28,8 @@ Description=Update Dynamic Wallpaper
 
 [Service]
 ExecStart={} {} update
-{}
 """.format(sys.executable,
-           os.path.dirname(os.path.abspath(__file__)),
-           "\n".join(f"Environment=\"{k}={v}\"" for (k,v) in os.environ.items() if "%" not in v))
+           os.path.dirname(os.path.abspath(__file__)))
 
 DEFAULT_TIMERNAME = "dynwalls.timer"
 


### PR DESCRIPTION
Hi @boi4,

I solved half of the #1 issue :slightly_smiling_face: 
I just removed Environment variables as they are not used in the service or in the default command (feh). Maybe this is for your initial needs? We can invert the algorithm by keeping only required variables instead of removing the ones which are not required.

As you certainly can notice, I also take the opportunity to make some improvements.
I added a `SYSTEMD_DIR` variable which targets the user systemd directory instead of creating symlinks which is not required. Maybe it was done on purpose for reason I don't know to create a specific directory for dynwalls resources and link service/timer into systemd directory. Let me know, I can revert this part but I found the improvements cleaner for the filesystem (less potential broken symlinks).

I also updated `DATA_DIR` and removed the trailing slash (the log of heic was `Written to $HOME/.local/share/dynwalls//images/wallpaper-96.jpg` instead of `Written to $HOME/.local/share/dynwalls/images/wallpaper-96.jpg`). I searched where the variable was used and added the missing slash where necessary.

It might be easier to read commit by commit. Let me know if you want me to create multiple PR.

I can see some other improvements which are more syntactic. For example:
```python
def setup_units(
		timelist,
		timerfile=DEFAULT_TIMERFILE,
		servicefile=DEFAULT_SERVICEFILE,
	):

    _create_timer(timelist, filename=timerfile)
    _create_service(filename=servicefile)
    reload()
```
instead of the original:
```python
def setup_units(timelist
                ,timerfile=DEFAULT_TIMERFILE
                ,servicefile=DEFAULT_SERVICEFILE):

    _create_timer(timelist, filename=timerfile)
    _create_service(filename=servicefile)
    reload()
```

The first syntax make the diff easier to read (less noisy) if an argument is removed/added.
Let me know, I can make another pr for this little improvements.